### PR TITLE
initial RPM spec (#1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,4 +26,9 @@ clean:
 docker-clean:
 	docker rmi memdisk-cloudwatch-build
 
+fetch-tarball: memdisk-cloudwatch.spec
+	mkdir -p $(shell rpm --eval "%{_sourcedir}")
+	spectool --get-files --sourcedir $<
 
+rpm: memdisk-cloudwatch.spec fetch-tarball
+	rpmbuild -ba $(RPMBUILD_FLAGS) $<

--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,10 @@ clean:
 docker-clean:
 	docker rmi memdisk-cloudwatch-build
 
-get-sources: memdisk-cloudwatch.spec memdisk-cloudwatch.service
+rpm-get-sources: memdisk-cloudwatch.spec memdisk-cloudwatch.service
 	rpmdev-setuptree
 	spectool --get-files --sourcedir $<
 	cp memdisk-cloudwatch.service $(shell rpm --eval "%{_sourcedir}")
 
-rpm: memdisk-cloudwatch.spec get-sources
+rpm: memdisk-cloudwatch.spec rpm-get-sources
 	rpmbuild -ba $(RPMBUILD_FLAGS) $<

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ docker-clean:
 	docker rmi memdisk-cloudwatch-build
 
 fetch-tarball: memdisk-cloudwatch.spec
-	mkdir -p $(shell rpm --eval "%{_sourcedir}")
+	rpmdev-setuptree
 	spectool --get-files --sourcedir $<
 
 rpm: memdisk-cloudwatch.spec fetch-tarball

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,9 @@
 
 all: clean build
 
-build:
+build: binary/memdisk-cloudwatch
+
+binary/memdisk-cloudwatch:
 	cd docker-build && docker build -t memdisk-cloudwatch-build .
 	docker run --rm \
 				-v $$(pwd)/binary:/go/bin \
@@ -26,10 +28,12 @@ clean:
 docker-clean:
 	docker rmi memdisk-cloudwatch-build
 
-rpm-get-sources: memdisk-cloudwatch.spec memdisk-cloudwatch.service
+RPM_SOURCEDIR=$(shell rpm --eval "%{_sourcedir}")
+
+rpm-get-sources: build memdisk-cloudwatch.spec memdisk-cloudwatch.service
 	rpmdev-setuptree
-	spectool --get-files --sourcedir $<
-	cp memdisk-cloudwatch.service $(shell rpm --eval "%{_sourcedir}")
+	cp binary/memdisk-cloudwatch $(RPM_SOURCEDIR)
+	cp memdisk-cloudwatch.service $(RPM_SOURCEDIR)
 
 rpm: memdisk-cloudwatch.spec rpm-get-sources
 	rpmbuild -ba $(RPMBUILD_FLAGS) $<

--- a/Makefile
+++ b/Makefile
@@ -26,9 +26,10 @@ clean:
 docker-clean:
 	docker rmi memdisk-cloudwatch-build
 
-fetch-tarball: memdisk-cloudwatch.spec
+get-sources: memdisk-cloudwatch.spec memdisk-cloudwatch.service
 	rpmdev-setuptree
 	spectool --get-files --sourcedir $<
+	cp memdisk-cloudwatch.service $(shell rpm --eval "%{_sourcedir}")
 
-rpm: memdisk-cloudwatch.spec fetch-tarball
+rpm: memdisk-cloudwatch.spec get-sources
 	rpmbuild -ba $(RPMBUILD_FLAGS) $<

--- a/README.md
+++ b/README.md
@@ -37,3 +37,17 @@ or this one on Sys-V:
 ```sh 
 curl -L https://raw.githubusercontent.com/AndrianBdn/memdisk-cloudwatch/master/install_sysv.sh | sh 
 ```
+
+## Building
+
+To generate `binary/memdisk-cloudwatch`:
+
+```sh
+make
+```
+
+To build an RPM (note: this requires the `rpmdevtools` package and depends on `systemd`):
+
+```sh
+make rpm
+```

--- a/memdisk-cloudwatch.service
+++ b/memdisk-cloudwatch.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=memdisk-cloudwatch: reporting mem&disk to cloudwatch
+
+[Service]
+Environment=HOME=/root
+; HOME environment is needed when AWS credentials are stored in /root/.aws/credentials file
+ExecStart=/usr/bin/memdisk-cloudwatch
+Restart=on-failure
+RestartSec=300
+
+[Install]
+WantedBy=multi-user.target

--- a/memdisk-cloudwatch.spec
+++ b/memdisk-cloudwatch.spec
@@ -9,7 +9,7 @@ Summary:        Monitoring Memory and Disk Metrics for Amazon EC2 Linux Instance
 Group:          Development/Tools
 License:        MIT
 URL:            https://github.com/AndrianBdn/memdisk-cloudwatch/
-Source0:        https://github.com/AndrianBdn/memdisk-cloudwatch/releases/download/v%{version}/%{name}-x86_64.gz
+Source0:        %{name}
 Source1:        %{name}.service
 BuildArch:      x86_64
 BuildRequires:  systemd
@@ -36,10 +36,7 @@ CentOS 6.x
 %build
 
 %install
-%{__mkdir} -p %{buildroot}%{_bindir}
-%{__gzip} -d -c %SOURCE0 > %{buildroot}%{_bindir}/%{name}
-%{__chmod} 0755 %{buildroot}%{_bindir}/%{name}
-
+%{__install} -p -m 0755 -D %{SOURCE0} %{buildroot}%{_bindir}/%{name}
 %{__install} -p -m 0644 -D %{SOURCE1} %{buildroot}%{_unitdir}/%{name}.service
 
 %post

--- a/memdisk-cloudwatch.spec
+++ b/memdisk-cloudwatch.spec
@@ -10,7 +10,9 @@ Group:          Development/Tools
 License:        MIT
 URL:            https://github.com/AndrianBdn/memdisk-cloudwatch/
 Source0:        https://github.com/AndrianBdn/memdisk-cloudwatch/releases/download/v%{version}/%{name}-x86_64.gz
+Source1:        %{name}.service
 BuildArch:      x86_64
+BuildRequires:  systemd
 
 %description
 This is the replacement for example CloudWatch scripts by Amazon
@@ -38,12 +40,24 @@ CentOS 6.x
 %{__gzip} -d -c %SOURCE0 > %{buildroot}%{_bindir}/%{name}
 %{__chmod} 0755 %{buildroot}%{_bindir}/%{name}
 
+%{__install} -p -m 0644 -D %{SOURCE1} %{buildroot}%{_unitdir}/%{name}.service
+
+%post
+%systemd_post %{name}.service
+
+%preun
+%systemd_preun %{name}.service
+
+%postun
+%systemd_postun_with_restart %{name}.service
+
 %clean
 rm -rf %{buildroot}
 
 %files
-%attr(0755,root,root)
+%defattr(-,root,root,-)
 %{_bindir}/%{name}
+%{_unitdir}/%{name}.service
 
 %changelog
 * Wed Oct 17 2018 Evan Zacks <zackse@gmail.com> 0.9.2-1

--- a/memdisk-cloudwatch.spec
+++ b/memdisk-cloudwatch.spec
@@ -1,0 +1,50 @@
+# don't install debuginfo -- this package is just a Go binary
+%global debug_package %{nil}
+%global __debug_install_post /bin/true
+
+Name:           memdisk-cloudwatch
+Version:        0.9.2
+Release:        1%{?dist}
+Summary:        Monitoring Memory and Disk Metrics for Amazon EC2 Linux Instances
+Group:          Development/Tools
+License:        MIT
+URL:            https://github.com/AndrianBdn/memdisk-cloudwatch/
+Source0:        https://github.com/AndrianBdn/memdisk-cloudwatch/releases/download/v%{version}/%{name}-x86_64.gz
+BuildArch:      x86_64
+
+%description
+This is the replacement for example CloudWatch scripts by Amazon
+(CloudWatchMonitoringScripts, see Monitoring Memory and Disk Metrics for Amazon
+EC2 Linux Instances.)
+
+This program is written in Go, the binary is statically linked and does not
+require any dependencies.
+
+This monitoring program is intended for use with Amazon EC2 instances running
+Linux operating systems. It has been tested on the 64-bit versions of the
+following Amazon Machine Images (AMIs):
+
+Amazon Linux 2014.09.2
+Ubuntu Server 16.04
+CentOS 6.x
+
+# not using %setup since the upstream package is not a tarball
+%prep
+
+%build
+
+%install
+%{__mkdir} -p %{buildroot}%{_bindir}
+%{__gzip} -d -c %SOURCE0 > %{buildroot}%{_bindir}/%{name}
+%{__chmod} 0755 %{buildroot}%{_bindir}/%{name}
+
+%clean
+rm -rf %{buildroot}
+
+%files
+%attr(0755,root,root)
+%{_bindir}/%{name}
+
+%changelog
+* Wed Oct 17 2018 Evan Zacks <zackse@gmail.com> 0.9.2-1
+- Initial RPM package.


### PR DESCRIPTION
This adds a new make target `rpm`. Note: the `rpmdevtools` package is required for `rpmbuild` and `spectool`.

I did not include a systemd unit or crontab (from the SysV install script). Do you have a preference? We can make the systemd unit conditional in the RPM spec if desired.

```bash
$ make rpm
mkdir -p /home/zackse/rpmbuild/SOURCES
spectool --get-files --sourcedir memdisk-cloudwatch.spec
Getting https://github.com/AndrianBdn/memdisk-cloudwatch/releases/download/v0.9.2/memdisk-cloudwatch-x86_64.gz to /home/zackse/rpmbuild/SOURCES/memdisk-cloudwatch-x86_64.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 2314k  100 2314k    0     0  1767k      0  0:00:01  0:00:01 --:--:-- 2227k
rpmbuild -ba  memdisk-cloudwatch.spec
...
Wrote: /home/zackse/rpmbuild/RPMS/x86_64/memdisk-cloudwatch-0.9.2-1.el7.centos.x86_64.rpm

$ rpm -qplv /home/zackse/rpmbuild/RPMS/x86_64/memdisk-cloudwatch-0.9.2-1.el7.centos.x86_64.rpm
-rwxr-xr-x    1 root    root                  4970064 Oct 17 08:33 /usr/bin/memdisk-cloudwatch
```